### PR TITLE
fix/mitigate secret key security vulnerability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ SERVER_SECRET_KEY=your_server_private_key_here
 # OPTIONAL CONFIGURATION
 # =============================================================================
 
+# =============================================================================
+# CONFIG MANAGER AUTHENTICATION
+# =============================================================================
+
+# Credentials for the web-based config manager (port 3000)
+# If not set, a random password will be generated on startup and printed to the console
+# MANAGER_USER=admin
+# MANAGER_PASSWORD=your_secure_password_here
+
 # Default perspective pubkey for trust calculations (hex format)
 # Default: Gigi's pubkey (6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93)
 DEFAULT_SOURCE_PUBKEY=6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,8 @@ services:
       - ./plugins:/usr/src/app/plugins
 
     ports:
-      - 3000:3000
+      # Bind to localhost by default to prevent accidental public exposure
+      - 127.0.0.1:3000:3000
 
     # Restart policy for production reliability
     restart: unless-stopped

--- a/manager.ts
+++ b/manager.ts
@@ -3,6 +3,7 @@
 /** Entry point for the config and process manager */
 import { startServer } from "process-pastry";
 import { parseArgs } from "util";
+import { randomBytes } from "crypto";
 
 import configApp from "./config-ui/index.html";
 
@@ -22,6 +23,17 @@ const { values } = parseArgs({
   allowPositionals: true,
 });
 
+const managerUser = process.env.MANAGER_USER || "admin";
+let managerPassword = process.env.MANAGER_PASSWORD;
+
+if (!managerPassword) {
+  managerPassword = randomBytes(16).toString("hex");
+  console.log(`\n⚠️  WARNING: No MANAGER_PASSWORD set in environment.`);
+  console.log(`🔒 Generated temporary password for config manager:`);
+  console.log(`   User: ${managerUser}`);
+  console.log(`   Password: ${managerPassword}\n`);
+}
+
 // Start process-pastry server with the bundled HTML
 startServer({
   port: 3000,
@@ -29,6 +41,8 @@ startServer({
   command: values.command
     ? values.command.split(" ")
     : ["bun", "run", "src/mcp/server.ts"],
+  authUser: managerUser,
+  authPassword: managerPassword,
   // Expose existing environment variables to the config UI
   expose: [
     "SERVER_SECRET_KEY",


### PR DESCRIPTION
## Description

This PR addresses a critical security vulnerability where the `process-pastry` configuration manager was exposed without authentication. Because the `startServer` config omitted credentials, `process-pastry` bypassed authentication entirely, leaving sensitive endpoints (like `/process-pastry/api/existing` and `/process-pastry/api/config`) publicly accessible. This allowed unauthenticated reads of `SERVER_SECRET_KEY` and arbitrary environment variable writes/process restarts.

To comprehensively harden the service, this PR introduces a 2-layer defense mechanism.

### Changes Made
1. **Enforced Basic Auth:** Updated `manager.ts` to inject `authUser` and `authPassword` from the environment (`MANAGER_USER` / `MANAGER_PASSWORD`).
2. **Auto-Generated Secure Defaults:** If a user forgets to set a `MANAGER_PASSWORD` in their environment, the manager will now generate a 16-byte cryptographically secure random password on startup and print it to the console. The manager will *never* start unprotected.
3. **Localhost Binding:** Updated `docker-compose.yml` to bind port `3000` exclusively to `127.0.0.1` by default. This prevents Docker from accidentally bypassing host firewalls (like UFW) and exposing the dashboard to the public internet on standard VPS deployments.
4. **Documentation:** Updated `.env.example` to include the new authentication variables.

## How to Test
1. Run the service using Docker Compose: `docker-compose up --build`.
2. Observe the startup logs. If you haven't set `MANAGER_PASSWORD` in your `.env`, you should see a newly generated password printed in the console.
3. Attempt to access `http://localhost:3000/process-pastry/api/config` from an external tool (like cURL or Postman) without auth. You should receive a `401 Unauthorized` response.
4. Access `http://localhost:3000` in your browser. You will be prompted for Basic Auth. Use `admin` (or your custom user) and the generated password to log in successfully.
5. Verify that the port is only bound locally by running `netstat -tuln | grep 3000` (it should bind to `127.0.0.1:3000`).
